### PR TITLE
Switch to AL2023 for python3.11

### DIFF
--- a/ami.tf
+++ b/ami.tf
@@ -1,9 +1,9 @@
 locals {
-  leader_ami_id = var.leader_ami_id == "" ? data.aws_ami.amazon_linux_2.id : var.leader_ami_id
-  nodes_ami_id  = var.nodes_ami_id == "" ? data.aws_ami.amazon_linux_2.id : var.nodes_ami_id
+  leader_ami_id = var.leader_ami_id == "" ? data.aws_ami.amazon_linux_2023.id : var.leader_ami_id
+  nodes_ami_id  = var.nodes_ami_id == "" ? data.aws_ami.amazon_linux_2023.id : var.nodes_ami_id
 }
 
-data "aws_ami" "amazon_linux_2" {
+data "aws_ami" "amazon_linux_2023" {
   most_recent = true
   filter {
     name   = "owner-alias"
@@ -12,6 +12,6 @@ data "aws_ami" "amazon_linux_2" {
   owners = ["amazon"]
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm*"]
+    values = ["al2023-ami-*"]
   }
 }

--- a/scripts/locust.entrypoint.leader.full.sh.tpl
+++ b/scripts/locust.entrypoint.leader.full.sh.tpl
@@ -1,14 +1,24 @@
 #!/bin/bash
 
-sudo yum update -y
-sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
+sudo dnf update -y
+sudo dnf install -y --allowerasing pcre2-devel.x86_64 python3.11 gcc python3.11-devel tzdata unzip bash htop python3.11-pip
+sudo dnf remove -y python3-requests
+
+# Set up alternatives to use Python 3.11 by default
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
+echo "2" | sudo alternatives --config python3
+
+# Set up alternatives to use pip3 for Python 3.11 by default
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.9 1
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 2
+echo "2" | sudo alternatives --config pip3
+
+sudo pip3 install requests
 
 # LOCUST
 export LOCUST_VERSION="2.29.0"
-sudo pip3 uninstall urllib3
-sudo pip3 install urllib3==1.26.6
-sudo pip3 install locust_plugins
-sudo pip3 install locust==$LOCUST_VERSION
+sudo pip3 install locust==$LOCUST_VERSION --log pip_install.log
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')
 echo "PRIVATE_IP=$PRIVATE_IP" >> /etc/environment
@@ -18,6 +28,9 @@ source ~/.bashrc
 mkdir -p ~/.ssh
 echo 'Host *' > ~/.ssh/config
 echo 'StrictHostKeyChecking no' >> ~/.ssh/config
+
+sudo pip3 install "urllib3<2.0"
+sudo pip3 install locust_plugins
 
 sudo iptables -A INPUT -i eth0 -p tcp --dport 80 -j ACCEPT
 sudo iptables -A INPUT -i eth0 -p tcp --dport 8080 -j ACCEPT

--- a/scripts/locust.entrypoint.node.full.sh.tpl
+++ b/scripts/locust.entrypoint.node.full.sh.tpl
@@ -1,14 +1,27 @@
 #!/bin/bash
 
-sudo yum update -y
-sudo yum install -y pcre2-devel.x86_64 python gcc python3-devel tzdata curl unzip bash htop
+sudo dnf update -y
+sudo dnf install -y --allowerasing pcre2-devel.x86_64 python3.11 gcc python3.11-devel tzdata unzip bash htop python3.11-pip
+sudo dnf remove -y python3-requests
+
+# Set up alternatives to use Python 3.11 by default
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2
+echo "2" | sudo alternatives --config python3
+
+# Set up alternatives to use pip3 for Python 3.11 by default
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.9 1
+sudo alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 2
+echo "2" | sudo alternatives --config pip3
+
+sudo pip3 install requests
 
 # LOCUST
 export LOCUST_VERSION="2.29.0"
-sudo pip3 uninstall urllib3
-sudo pip3 install urllib3==1.26.6
-sudo pip3 install locust_plugins
-sudo pip3 install locust==$LOCUST_VERSION
+sudo pip3 install locust==$LOCUST_VERSION --log pip_install.log
+sudo pip3 uninstall urllib3 --log pip_install.log
+sudo pip3 install urllib3==1.26.6 --log pip_install.log
+sudo pip3 install locust_plugins --log pip_install.log
 
 export PRIVATE_IP=$(hostname -I | awk '{print $1}')
 echo "PRIVATE_IP=$PRIVATE_IP" >> /etc/environment


### PR DESCRIPTION
Some sending multipart requests (required for loom write testing) is only supported in the latest version of locust, which requires python3.10 minimum. This isn't available on AWS Linux 2, so I upgraded to AL2023, and forced the install of python 3.11, then set this as the alternative.